### PR TITLE
Fix for the user dropdown menu going out of the view

### DIFF
--- a/Seth/dashboard/templates/navbar.html
+++ b/Seth/dashboard/templates/navbar.html
@@ -33,7 +33,7 @@
               <button type="button" class="btn dropdown-toggle nav-button pointer" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <i class="material-icons md-light md-36">account_circle</i>
               </button>
-              <div class="dropdown-menu dropdown-menu-left">
+              <div id="user-dropdown" class="dropdown-menu dropdown-menu-left">
                   {% if user.is_authenticated %}
                   <h6 class="dropdown-header">Current user: {{ user.username }}</h6>
                   <div class="dropdown-divider"></div>

--- a/Seth/static/Seth/seth/js/scripts.js
+++ b/Seth/static/Seth/seth/js/scripts.js
@@ -451,6 +451,19 @@ $(document).ready(function() {
 
     $("#snackbarClose").on('click', function() {
         $("#snackbar").fadeOut(500);
+    });
+
+    // Switch the logout menu depending on screen size.
+    $(window).on('resize', function() {
+        console.log("Window resized");
+        var $userDropdown = $("#user-dropdown");
+        if ($(window).width() < 992) {
+           $userDropdown.removeClass("dropdown-menu-left");
+           $userDropdown.addClass("dropdown-menu-right");
+        } else {
+            $userDropdown.removeClass("dropdown-menu-right");
+            $userDropdown.addClass("dropdown-menu-left");
+        }
     })
 });
 


### PR DESCRIPTION
The user dropdown now switches from right to left under the button, depending on screen size, and thus if the navbar is collapsed